### PR TITLE
Delete task memory on task removal

### DIFF
--- a/src/infrastructure/mcp/http_server.rs
+++ b/src/infrastructure/mcp/http_server.rs
@@ -71,12 +71,16 @@ pub async fn start_tasks_server(db_path: String, port: u16) -> Result<()> {
         .context("Failed to run database migrations")?;
 
     let task_repo = Arc::new(TaskRepositoryImpl::new(db.pool().clone()));
+    let memory_repo = Arc::new(MemoryRepositoryImpl::new(db.pool().clone()));
+    let memory_service = Arc::new(MemoryService::new(memory_repo));
+
     let dependency_resolver = DependencyResolver::new();
     let priority_calc = PriorityCalculator::new();
-    let task_service = Arc::new(TaskQueueService::new(
+    let task_service = Arc::new(TaskQueueService::with_memory_service(
         task_repo.clone(),
         dependency_resolver,
         priority_calc,
+        memory_service,
     ));
 
     info!("Database initialized successfully");

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,16 +65,19 @@ async fn main() -> Result<()> {
     // Initialize services
     let dependency_resolver = DependencyResolver::new();
     let priority_calc = PriorityCalculator::new();
-    let real_task_service = RealTaskQueueService::new(
+
+    // Initialize real memory service with repository and adapter
+    let real_memory_service = Arc::new(RealMemoryService::new(memory_repo));
+    let memory_service = MemoryServiceAdapter::new(real_memory_service.clone());
+
+    // Initialize task service with memory service for cleanup
+    let real_task_service = RealTaskQueueService::with_memory_service(
         task_repo.clone(),
         dependency_resolver,
         priority_calc,
+        real_memory_service,
     );
     let task_service = TaskQueueServiceAdapter::new(real_task_service);
-
-    // Initialize real memory service with repository and adapter
-    let real_memory_service = RealMemoryService::new(memory_repo);
-    let memory_service = MemoryServiceAdapter::new(real_memory_service);
 
     match cli.command {
         Commands::Init { .. } => {


### PR DESCRIPTION
When tasks are deleted via the prune operation, their associated memory entries (stored with namespace pattern `task:{task_id}:*`) are now also deleted automatically.

Changes:
- Added optional memory_service field to TaskQueueService
- Added with_memory_service() constructor for TaskQueueService
- Added delete_task_memory() method to clean up task-specific memory
- Updated validate_and_prune_tasks() to call delete_task_memory()
- Updated main.rs to initialize TaskQueueService with memory service
- Updated http_server.rs MCP server to initialize with memory service

This prevents memory leaks and maintains data consistency when tasks are removed from the queue. Memory deletion is non-blocking - if it fails, the task is still deleted successfully.