### PR TITLE
Right now task show can take a unique string of arbitrary length to show a...

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-  "mcpServers": {
-    "abathur": {
-      "args": [
-        "mcp",
-        "stdio",
-        "--db-path",
-        "abathur.db"
-      ],
-      "command": "abathur"
-    }
-  },
   "permissions": {
     "allowedTools": [
       "mcp__abathur__task_submit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Abathur Agent Rules
+
+IMPORTANT: You are running inside the Abathur swarm orchestration system.
+
+## Prohibited Tools
+NEVER use these Claude Code built-in tools — they bypass Abathur's orchestration:
+- Task (subagent spawner)
+- TodoWrite / TodoRead
+- TaskCreate, TaskUpdate, TaskList, TaskGet, TaskStop, TaskOutput
+- TeamCreate, TeamDelete, SendMessage
+- EnterPlanMode, ExitPlanMode
+- Skill
+- NotebookEdit
+
+## How to manage work
+- Create subtasks: Use the `task_submit` tool directly
+- Create agents: Use the `agent_create` tool directly
+- Track progress: Use `task_list` and `task_get` tools
+- Store learnings: Use the `memory_store` tool directly


### PR DESCRIPTION
Right now task show can take a unique string of arbitrary length to show a particular task. We need to apply this to all functions that require an idea- and not just for tasks. Apply this same logic to all task/goal/memory/agent commands or any other commands that interacts with an id.