### PR TITLE
Research: Fuzzy ID matching in CLI commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-  "mcpServers": {
-    "abathur": {
-      "args": [
-        "mcp",
-        "stdio",
-        "--db-path",
-        "abathur.db"
-      ],
-      "command": "abathur"
-    }
-  },
   "permissions": {
     "allowedTools": [
       "mcp__abathur__task_submit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Abathur Agent Rules
+
+IMPORTANT: You are running inside the Abathur swarm orchestration system.
+
+## Prohibited Tools
+NEVER use these Claude Code built-in tools — they bypass Abathur's orchestration:
+- Task (subagent spawner)
+- TodoWrite / TodoRead
+- TaskCreate, TaskUpdate, TaskList, TaskGet, TaskStop, TaskOutput
+- TeamCreate, TeamDelete, SendMessage
+- EnterPlanMode, ExitPlanMode
+- Skill
+- NotebookEdit
+
+## How to manage work
+- Create subtasks: Use the `task_submit` tool directly
+- Create agents: Use the `agent_create` tool directly
+- Track progress: Use `task_list` and `task_get` tools
+- Store learnings: Use the `memory_store` tool directly


### PR DESCRIPTION
Research the codebase to understand:

1. **How "task show" currently implements fuzzy/prefix ID matching** - Find the exact function that resolves a partial/unique string to a full task ID. Understand the logic (prefix match? substring? how it handles ambiguity?).

2. **All CLI commands that take an ID parameter** - Find every command handler for tasks, goals, memories, agents, events, and any other entity types. For each one, document:
   - The command name (e.g., "task show", "goal delete", etc.)
   - The file and function where it's implemented
   - How it currently resolves its ID argument (does it already use fuzzy matching, or does it require a full exact ID?)

3. **The project structure** - What language is this? How are CLI commands organized? What's the module structure?

4. **Existing ID resolution utilities** - Is there a shared function/trait for fuzzy ID resolution, or is it inline in the task show handler? Could it be generalized?

5. **All entity types that have IDs** - tasks, goals, memories, agents, events, etc. For each, how are IDs stored and queried?

Be extremely thorough. List every single command that takes an ID and whether it already has fuzzy matching or not.