### PR TITLE
Research: prefix-match ID lookup across all CLI commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-  "mcpServers": {
-    "abathur": {
-      "args": [
-        "mcp",
-        "stdio",
-        "--db-path",
-        "abathur.db"
-      ],
-      "command": "abathur"
-    }
-  },
   "permissions": {
     "allowedTools": [
       "mcp__abathur__task_submit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Abathur Agent Rules
+
+IMPORTANT: You are running inside the Abathur swarm orchestration system.
+
+## Prohibited Tools
+NEVER use these Claude Code built-in tools — they bypass Abathur's orchestration:
+- Task (subagent spawner)
+- TodoWrite / TodoRead
+- TaskCreate, TaskUpdate, TaskList, TaskGet, TaskStop, TaskOutput
+- TeamCreate, TeamDelete, SendMessage
+- EnterPlanMode, ExitPlanMode
+- Skill
+- NotebookEdit
+
+## How to manage work
+- Create subtasks: Use the `task_submit` tool directly
+- Create agents: Use the `agent_create` tool directly
+- Track progress: Use `task_list` and `task_get` tools
+- Store learnings: Use the `memory_store` tool directly


### PR DESCRIPTION
Explore the Abathur codebase to understand:

1. **Current `task show` prefix-matching logic**: Find where the `task show` command resolves a partial/unique string to a full task ID. Identify the exact function/method that does this prefix matching, the file it's in, and how it works.

2. **All CLI commands that take an ID parameter**: Find ALL commands across all entity types (tasks, goals, memories, agents, events, and any others) that accept an ID as input. For each one, document:
   - The command name (e.g., `task show`, `goal update`, `memory get`, etc.)
   - The file and function where the ID is received/parsed
   - How the ID is currently resolved (full UUID? prefix match? something else?)

3. **Entity types and their storage**: Identify all entity types that have IDs (tasks, goals, memories, agents, events, etc.) and how they are stored/retrieved. Find the storage/database layer for each.

4. **Existing helper/utility functions**: Look for any shared utility for ID resolution that might already exist, or if the prefix matching in `task show` is inline.

5. **CLI command structure**: Understand how CLI commands are structured (what framework, how arguments are parsed, how commands are organized).

Report all findings comprehensively with exact file paths, line numbers, and code snippets so an implementation plan can be made.