### PR TITLE
Right now task show can take a unique string of arbitrary length to show a...

### DIFF
--- a/src/cli/commands/swarm.rs
+++ b/src/cli/commands/swarm.rs
@@ -1267,11 +1267,12 @@ async fn show_escalations(json_mode: bool) -> Result<()> {
 }
 
 async fn respond_to_escalation(id: &str, decision: &str, message: Option<&str>, json_mode: bool) -> Result<()> {
+    use crate::adapters::sqlite::create_pool;
+    use crate::cli::id_resolver::resolve_event_id;
     use crate::domain::models::{EscalationDecision, HumanEscalationResponse};
-    use uuid::Uuid;
 
-    let event_id: Uuid = id.parse()
-        .map_err(|e| anyhow::anyhow!("Invalid escalation ID: {}", e))?;
+    let pool = create_pool("sqlite:.abathur/abathur.db", None).await?;
+    let event_id = resolve_event_id(&pool, id).await?;
 
     let escalation_decision = match decision {
         "accept" => EscalationDecision::Accept,

--- a/src/cli/id_resolver.rs
+++ b/src/cli/id_resolver.rs
@@ -39,6 +39,12 @@ pub async fn resolve_trigger_rule_id(pool: &SqlitePool, prefix: &str) -> Result<
         .await
 }
 
+/// Resolve an event ID prefix to a full UUID.
+pub async fn resolve_event_id(pool: &SqlitePool, prefix: &str) -> Result<Uuid> {
+    resolve_prefix(pool, prefix, "event", EVENT_QUERY)
+        .await
+}
+
 /// Resolve a dead letter entry ID prefix to a full ID string.
 ///
 /// Returns `String` rather than `Uuid` because the `EventStore` trait uses
@@ -53,6 +59,7 @@ const WORKTREE_QUERY: &str =
     "SELECT id FROM worktrees WHERE id LIKE ?1 UNION SELECT id FROM worktrees WHERE task_id LIKE ?1";
 const MEMORY_QUERY: &str = "SELECT id FROM memories WHERE id LIKE ?";
 const TRIGGER_RULE_QUERY: &str = "SELECT id FROM trigger_rules WHERE id LIKE ?";
+const EVENT_QUERY: &str = "SELECT id FROM events WHERE id LIKE ?";
 const DLQ_QUERY: &str = "SELECT id FROM dead_letter_events WHERE id LIKE ? AND resolved_at IS NULL";
 
 fn validate_prefix(prefix: &str) -> Result<()> {


### PR DESCRIPTION
Right now task show can take a unique string of arbitrary length to show a particular task. We need to apply this to all functions that require an idea- and not just for tasks. Apply this same logic to all task/goal/memory/agent commands or any other commands that interacts with an id.

## Subtasks

- [x] Review: prefix-based ID resolution implementation (complete)
- [x] Implement: unified prefix-based ID resolution for all commands (complete)
- [x] Plan: unified prefix-based ID resolution for all commands (complete)
- [x] Research: prefix-based ID resolution across all commands (complete)
