### PR TITLE
Fix split-brain dual orchestration on review loop

### DIFF
--- a/src/services/event_bus.rs
+++ b/src/services/event_bus.rs
@@ -264,6 +264,9 @@ pub enum EventPayload {
         iteration: u32,
         max_iterations: u32,
         new_plan_task_id: Uuid,
+        /// The new review task ID, stored as successor on the failed review task
+        /// so the parent orchestrating agent can follow the chain.
+        new_review_task_id: Uuid,
     },
 
     // Agent events


### PR DESCRIPTION
## Summary

When a review task fails, two independent actors both react to the failure event and each spawn their own fix track:

## Changes

### Commits

```
cb080d1 Fix split-brain dual orchestration on review loop failure
```

### Files Changed

```
src/domain/models/specialist_templates.rs |  12 ++-
 src/services/builtin_handlers.rs          | 157 ++++++++++++++++++++++++++++--
 src/services/event_bus.rs                 |   3 +
 3 files changed, 163 insertions(+), 9 deletions(-)
```

## Subtasks

- [x] Review: split-brain review loop fix (complete)
- [x] Implement split-brain review loop fix (complete)
- [x] Intent verification (iteration 0) (complete)
- [x] Intent verification (iteration 0) (complete)

---
🤖 Generated by [Abathur Swarm](https://github.com/abathur-swarm)
