### PR TITLE
Bug: error messages from transition_to are discarded — silent state machine failures

### DIFF
--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -12,8 +12,8 @@ pub enum DomainError {
     #[error("Task not found: {0}")]
     TaskNotFound(Uuid),
 
-    #[error("Invalid state transition from {from} to {to}")]
-    InvalidStateTransition { from: String, to: String },
+    #[error("Invalid state transition from {from} to {to}: {reason}")]
+    InvalidStateTransition { from: String, to: String, reason: String },
 
     #[error("Task dependency cycle detected involving task: {0}")]
     DependencyCycle(Uuid),

--- a/src/services/goal_service.rs
+++ b/src/services/goal_service.rs
@@ -99,9 +99,10 @@ impl<R: GoalRepository> GoalService<R> {
             .ok_or(DomainError::GoalNotFound(id))?;
 
         let from_status = goal.status;
-        goal.transition_to(new_status).map_err(|_| DomainError::InvalidStateTransition {
+        goal.transition_to(new_status).map_err(|e| DomainError::InvalidStateTransition {
             from: from_status.as_str().to_string(),
             to: new_status.as_str().to_string(),
+            reason: e,
         })?;
 
         self.repository.update(&goal).await?;

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -13,6 +13,7 @@ use crate::services::event_bus::{
     EventCategory, EventPayload, EventSeverity, UnifiedEvent,
 };
 use crate::services::event_factory;
+use tracing::warn;
 
 /// Configuration for spawn limits.
 #[derive(Debug, Clone)]
@@ -528,13 +529,15 @@ impl<T: TaskRepository> TaskService<T> {
             return Err(DomainError::InvalidStateTransition {
                 from: task.status.as_str().to_string(),
                 to: "running".to_string(),
+                reason: "task must be in Ready state to be claimed".to_string(),
             });
         }
 
         task.agent_type = Some(agent_type.to_string());
-        task.transition_to(TaskStatus::Running).map_err(|_| DomainError::InvalidStateTransition {
+        task.transition_to(TaskStatus::Running).map_err(|e| DomainError::InvalidStateTransition {
             from: task.status.as_str().to_string(),
             to: "running".to_string(),
+            reason: e,
         })?;
 
         self.task_repo.update(&task).await?;
@@ -566,9 +569,10 @@ impl<T: TaskRepository> TaskService<T> {
         let mut task = self.task_repo.get(task_id).await?
             .ok_or(DomainError::TaskNotFound(task_id))?;
 
-        task.transition_to(TaskStatus::Complete).map_err(|_| DomainError::InvalidStateTransition {
+        task.transition_to(TaskStatus::Complete).map_err(|e| DomainError::InvalidStateTransition {
             from: task.status.as_str().to_string(),
             to: "complete".to_string(),
+            reason: e,
         })?;
 
         self.task_repo.update(&task).await?;
@@ -620,9 +624,10 @@ impl<T: TaskRepository> TaskService<T> {
         let mut task = self.task_repo.get(task_id).await?
             .ok_or(DomainError::TaskNotFound(task_id))?;
 
-        task.transition_to(TaskStatus::Failed).map_err(|_| DomainError::InvalidStateTransition {
+        task.transition_to(TaskStatus::Failed).map_err(|e| DomainError::InvalidStateTransition {
             from: task.status.as_str().to_string(),
             to: "failed".to_string(),
+            reason: e,
         })?;
 
         let error_str = error_message.clone().unwrap_or_default();
@@ -737,9 +742,10 @@ impl<T: TaskRepository> TaskService<T> {
             ));
         }
 
-        task.transition_to(TaskStatus::Canceled).map_err(|_| DomainError::InvalidStateTransition {
+        task.transition_to(TaskStatus::Canceled).map_err(|e| DomainError::InvalidStateTransition {
             from: task.status.as_str().to_string(),
             to: "canceled".to_string(),
+            reason: e,
         })?;
 
         self.task_repo.update(&task).await?;
@@ -790,9 +796,23 @@ impl<T: TaskRepository> TaskService<T> {
         }
 
         if self.has_failed_dependency(task).await? {
-            task.transition_to(TaskStatus::Blocked).ok();
+            if let Err(e) = task.transition_to(TaskStatus::Blocked) {
+                warn!(task_id = %task.id, error = %e, "Failed to transition task to Blocked");
+                return Err(DomainError::InvalidStateTransition {
+                    from: task.status.as_str().to_string(),
+                    to: "blocked".to_string(),
+                    reason: e,
+                });
+            }
         } else if self.are_dependencies_complete(task).await? {
-            task.transition_to(TaskStatus::Ready).ok();
+            if let Err(e) = task.transition_to(TaskStatus::Ready) {
+                warn!(task_id = %task.id, error = %e, "Failed to transition task to Ready");
+                return Err(DomainError::InvalidStateTransition {
+                    from: task.status.as_str().to_string(),
+                    to: "ready".to_string(),
+                    reason: e,
+                });
+            }
         }
 
         Ok(())
@@ -869,10 +889,11 @@ impl<T: TaskRepository + 'static> TaskCommandHandler for TaskService<T> {
                     .get(task_id)
                     .await?
                     .ok_or(DomainError::TaskNotFound(task_id))?;
-                task.transition_to(new_status).map_err(|_| {
+                task.transition_to(new_status).map_err(|e| {
                     DomainError::InvalidStateTransition {
                         from: task.status.as_str().to_string(),
                         to: new_status.as_str().to_string(),
+                        reason: e,
                     }
                 })?;
                 self.task_repo.update(&task).await?;

--- a/src/services/worktree_service.rs
+++ b/src/services/worktree_service.rs
@@ -148,6 +148,7 @@ impl<W: WorktreeRepository> WorktreeService<W> {
             return Err(DomainError::InvalidStateTransition {
                 from: worktree.status.as_str().to_string(),
                 to: "completed".to_string(),
+                reason: "worktree must be in Active state to be completed".to_string(),
             });
         }
 
@@ -167,6 +168,7 @@ impl<W: WorktreeRepository> WorktreeService<W> {
             return Err(DomainError::InvalidStateTransition {
                 from: worktree.status.as_str().to_string(),
                 to: "merging".to_string(),
+                reason: "worktree must be in Completed state to merge".to_string(),
             });
         }
 


### PR DESCRIPTION
## Summary

[Ingested from github-issues — 70]

## Changes

### Commits

```
e2aff23 fix: surface state machine errors instead of silently discarding them
```

### Files Changed

```
src/domain/errors.rs             |  4 ++--
 src/services/goal_service.rs     |  3 ++-
 src/services/task_service.rs     | 35 ++++++++++++++++++++++++++++-------
 src/services/worktree_service.rs |  2 ++
 4 files changed, 34 insertions(+), 10 deletions(-)
```

## Subtasks

- [x] Research: TaskStatus state machine and error types (complete)
- [x] Research: task_service.rs transition_to error handling (complete)

---
🤖 Generated by [Abathur Swarm](https://github.com/abathur-swarm)
