### PR TITLE
Architecture: convergence trajectory records include unbounded JSON arrays — memory risk for long-running convergence loops

### DIFF
--- a/src/services/builtin_handlers.rs
+++ b/src/services/builtin_handlers.rs
@@ -550,7 +550,7 @@ impl<T: TaskRepository + 'static> EventHandler for TaskFailedRetryHandler<T> {
                 "consecutive_budget_failures".to_string(),
                 serde_json::json!(consecutive),
             );
-            updated.context.hints.push("retry:max_turns_exceeded".to_string());
+            updated.context.push_hint_bounded("retry:max_turns_exceeded".to_string());
             updated.context.custom.insert(
                 "last_failure_reason".to_string(),
                 serde_json::Value::String(error.to_string()),
@@ -4295,9 +4295,9 @@ impl<T: TaskRepository + 'static> EventHandler for ConvergenceSLAPressureHandler
         // When escalating to critical, also ensure warning hint is present
         let mut updated = task.clone();
         if hint == "sla:critical" && !updated.context.hints.iter().any(|h| h == "sla:warning") {
-            updated.context.hints.push("sla:warning".to_string());
+            updated.context.push_hint_bounded("sla:warning".to_string());
         }
-        updated.context.hints.push(hint.to_string());
+        updated.context.push_hint_bounded(hint.to_string());
         updated.updated_at = chrono::Utc::now();
 
         self.task_repo.update(&updated).await

--- a/src/services/convergence_engine.rs
+++ b/src/services/convergence_engine.rs
@@ -595,9 +595,9 @@ impl<T: TrajectoryRepository, M: MemoryRepository, O: OverseerMeasurer>
             obs_with_metrics = obs_with_metrics.with_verification(verification);
         }
 
-        // Push observation
-        trajectory.observations.push(obs_with_metrics);
-        trajectory.strategy_log.push(entry);
+        // Push observation (bounded to prevent unbounded JSON growth)
+        trajectory.push_observation_bounded(obs_with_metrics);
+        trajectory.push_strategy_log_bounded(entry);
 
         // Emit ObservationRecorded
         if let Some(obs) = trajectory.observations.last() {

--- a/src/services/intent_verifier.rs
+++ b/src/services/intent_verifier.rs
@@ -1020,7 +1020,7 @@ where
         error: &str,
     ) -> DomainResult<()> {
         if let Ok(Some(mut task)) = self.task_repo.get(verification_task_id).await {
-            task.context.hints.push(format!("Error: {}", error));
+            task.context.push_hint_bounded(format!("Error: {}", error));
             let _ = task.transition_to(TaskStatus::Failed);
             let _ = self.task_repo.update(&task).await;
         }

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -627,7 +627,7 @@ impl<T: TaskRepository> TaskService<T> {
 
         let error_str = error_message.clone().unwrap_or_default();
         if let Some(msg) = error_message {
-            task.context.hints.push(format!("Error: {}", msg));
+            task.context.push_hint_bounded(format!("Error: {}", msg));
         }
 
         self.task_repo.update(&task).await?;
@@ -704,7 +704,7 @@ impl<T: TaskRepository> TaskService<T> {
                 h.to_lowercase().contains("trapped")
             });
             if is_trapped {
-                task.context.hints.push("convergence:fresh_start".to_string());
+                task.context.push_hint_bounded("convergence:fresh_start".to_string());
             }
         }
 


### PR DESCRIPTION
## Summary

[Ingested from github-issues — 71]

## Changes

### Commits

```
ba92b58 Bound JSON arrays to prevent unbounded growth in convergence trajectories and task context
```

### Files Changed

```
src/adapters/sqlite/task_repository.rs       |  19 ++++
 src/adapters/sqlite/trajectory_repository.rs |  19 ++++
 src/domain/models/convergence/trajectory.rs  | 135 +++++++++++++++++++++++++++
 src/domain/models/task.rs                    |  56 +++++++++++
 src/services/builtin_handlers.rs             |   6 +-
 src/services/convergence_engine.rs           |   6 +-
 src/services/intent_verifier.rs              |   2 +-
 src/services/task_service.rs                 |   4 +-
 8 files changed, 238 insertions(+), 9 deletions(-)
```

## Subtasks

- [x] Review: Bound JSON arrays implementation (issue #71) (complete)
- [x] Implement: Bound JSON arrays — hints cap, observation windowing, size monitoring (complete)
- [x] Plan: JSON array bounding for hints and convergence trajectories (complete)
- [x] Research: convergence_trajectories table and observation windowing (complete)
- [x] Research: task_service.rs hints/context handling (complete)
- [x] Intent verification (iteration 0) (complete)
- [x] Intent verification (iteration 0) (complete)

---
🤖 Generated by [Abathur Swarm](https://github.com/abathur-swarm)
