### PR TITLE
Bug: Guardrails token reset_hourly() is never called — hourly limit never resets

### DIFF
--- a/src/services/swarm_orchestrator/mod.rs
+++ b/src/services/swarm_orchestrator/mod.rs
@@ -482,6 +482,14 @@ where
             }
         }
 
+        // Start guardrails hourly token counter reset
+        self.start_guardrails_hourly_reset();
+        self.audit_log.info(
+            AuditCategory::System,
+            AuditAction::SwarmStarted,
+            "Guardrails hourly token reset task started",
+        ).await;
+
         // Refresh active goals cache for agent context
         if let Err(e) = self.refresh_active_goals_cache().await {
             self.audit_log.log(


### PR DESCRIPTION
## Summary

[Ingested from github-issues — 42]
GitHub Issue: https://github.com/odgrim/abathur-swarm/issues/42

## Changes

### Commits

```
d81ce8f fix: schedule hourly reset of guardrails token counter at swarm startup
```

### Files Changed

```
src/services/guardrails.rs                        | 25 +++++++++++++++++++++++
 src/services/swarm_orchestrator/infrastructure.rs | 23 +++++++++++++++++++++
 src/services/swarm_orchestrator/mod.rs            |  8 ++++++++
 3 files changed, 56 insertions(+)
```

## Subtasks

- [x] Triage: GitHub Issue #42 — reset_hourly never called (complete)

---
🤖 Generated by [Abathur Swarm](https://github.com/abathur-swarm)
