### PR TITLE
perf(task_service): use lightweight get_parent_id for depth/root traversal

### DIFF
--- a/src/domain/ports/task_repository.rs
+++ b/src/domain/ports/task_repository.rs
@@ -75,4 +75,11 @@ pub trait TaskRepository: Send + Sync {
     /// Uses `UPDATE ... WHERE status = 'ready'` to prevent TOCTOU races.
     /// Returns `Ok(None)` if the task was already claimed or not in Ready state.
     async fn claim_task_atomic(&self, task_id: Uuid, agent_type: &str) -> DomainResult<Option<Task>>;
+
+    /// Get only the parent_id for a task, without loading the full struct.
+    ///
+    /// Returns `Ok(None)` if the task does not exist or has no parent.
+    /// This is used for lightweight ancestry traversal (depth calculation,
+    /// root-finding) to avoid cloning entire `Task` structs at each level.
+    async fn get_parent_id(&self, task_id: Uuid) -> DomainResult<Option<Uuid>>;
 }

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -186,20 +186,20 @@ impl<T: TaskRepository> TaskService<T> {
     }
 
     /// Calculate the depth of a task in the hierarchy (0 = root).
+    ///
+    /// Uses lightweight `get_parent_id` queries to traverse the ancestry chain
+    /// without loading full `Task` structs at each level.
     async fn calculate_depth(&self, task: &Task) -> DomainResult<u32> {
         let mut depth = 0;
-        let mut current = task.clone();
+        let mut current_parent = task.parent_id;
 
-        while let Some(parent_id) = current.parent_id {
+        while let Some(pid) = current_parent {
             depth += 1;
             if depth > 100 {
                 // Safety limit to prevent infinite loops
                 break;
             }
-            match self.task_repo.get(parent_id).await? {
-                Some(parent) => current = parent,
-                None => break,
-            }
+            current_parent = self.task_repo.get_parent_id(pid).await?;
         }
 
         Ok(depth)
@@ -216,17 +216,17 @@ impl<T: TaskRepository> TaskService<T> {
     }
 
     /// Find the root task (task with no parent).
+    ///
+    /// Uses lightweight `get_parent_id` queries to walk up the task tree
+    /// without allocating full `Task` structs at each level.
     async fn find_root_task(&self, task: &Task) -> DomainResult<Uuid> {
-        let mut current = task.clone();
+        let mut current_id = task.id;
 
-        while let Some(parent_id) = current.parent_id {
-            match self.task_repo.get(parent_id).await? {
-                Some(parent) => current = parent,
-                None => break,
-            }
+        while let Some(pid) = self.task_repo.get_parent_id(current_id).await? {
+            current_id = pid;
         }
 
-        Ok(current.id)
+        Ok(current_id)
     }
 
     /// Count all descendants of a task using iterative BFS.


### PR DESCRIPTION
…ersal

Fixes #65

- Added get_parent_id(task_id) -> Option<Uuid> to the TaskRepository trait  queries only the parent_id column instead of SELECT *.
- Implemented in SqliteTaskRepository with a single-column query.
- Refactored calculate_depth and ind_root_task to use the new method instead of cloning entire Task structs at every hierarchy level.
- Reduces allocations from O(depth  sizeof(Task)) to O(depth  sizeof(Uuid)).

submitted by Polish's bot :)